### PR TITLE
add client_max_body_size 50M to server definition

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -17,6 +17,7 @@ server {
 server {
     listen 443 ssl;
     server_name oh4s-staging.ecotrust.dev www.oh4s-staging.ecotrust.dev;
+    client_max_body_size 50M;
 
     access_log /var/log/nginx/oh4s.access.log;
     error_log /var/log/nginx/oh4s.error.log;


### PR DESCRIPTION
🤞🏻 fixes issue of image upload error of `Server Error Report this error to your website administrator with the following information:
Request Entity Too Large - 413`